### PR TITLE
Require either `requirements.txt` or `poetry`

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -416,13 +416,8 @@ func PythonFileRequirements(filenames []string, logger log.Logger) (bool, error)
 	if err != nil {
 		return false, err
 	}
-	if !has_reqs_txt {
-		logger.Infof("Missing requirements.txt")
-	}
-	if !has_pyproject {
-		logger.Infof("Missing pyproject.toml")
-	}
 	if !has_reqs_txt && !has_pyproject {
+		logger.Infof("Missing a dependency manager: either add requirements.txt or pyproject.toml")
 		meets_reqs = false
 	}
 	return meets_reqs, nil

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -416,13 +416,13 @@ func PythonFileRequirements(filenames []string, logger log.Logger) (bool, error)
 	if err != nil {
 		return false, err
 	}
-	if !has_reqs_txt || !has_pyproject {
-		if !has_reqs_txt {
-			logger.Infof("Missing requirements.txt")
-		}
-		if !has_pyproject {
-			logger.Infof("Missing pyproject.toml")
-		}
+	if !has_reqs_txt {
+		logger.Infof("Missing requirements.txt")
+	}
+	if !has_pyproject {
+		logger.Infof("Missing pyproject.toml")
+	}
+	if !has_reqs_txt && !has_pyproject {
 		meets_reqs = false
 	}
 	return meets_reqs, nil

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -6,11 +6,12 @@ import (
 	"log"
 	"os"
 
+	"testing"
+
 	mocks "github.com/arcalot/arcaflow-plugin-image-builder/mocks/mock_ce_client"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	arcalog "go.arcalot.io/log"
-	"testing"
 )
 
 func IntMin(a, b int) int {


### PR DESCRIPTION
## Changes introduced with this PR

When using `poetry` for handling dependencies `requirements.txt` is not required.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).