### PR TITLE
fix python file requirements test

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -111,7 +111,7 @@ func TestImageLanguage(t *testing.T) {
 }
 
 func TestPythonFileRequirements(t *testing.T) {
-	min_correct := []string{"requirements.txt", "app.py", "pyproject.toml"}
+	min_correct := []string{"requirements.txt", "app.py", "main.py", "pyproject.toml"}
 	testCases := map[string]struct {
 		filenames      []string
 		expectedResult bool
@@ -122,10 +122,18 @@ func TestPythonFileRequirements(t *testing.T) {
 		},
 		"b": {
 			min_correct[:1],
-			false,
+			true,
 		},
 		"c": {
 			min_correct[2:],
+			true,
+		},
+		"d": {
+			min_correct[1:3],
+			false,
+		},
+		"e": {
+			[]string{},
 			false,
 		},
 	}


### PR DESCRIPTION
## Changes introduced with this PR

Update test to allow for valid lists of python project files such that it can contain a `requirements.txt` or a `pyproject.toml`.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).