### PR TITLE
removed unused Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-generate-mocks:
-	mockgen -source=internal/docker/dockerClient.go -destination=mocks/docker/dockerClient.go
-	mockgen -source=internal/ce_client/ce_client.go -destination=mocks/ce_client/ce_client.go


### PR DESCRIPTION
## Changes introduced with this PR

This PR removes the Makefile containing only one target for `go generate`, which is already handled via `go:generate` in [mocks/generate.go](https://github.com/arcalot/arcaflow-plugin-image-builder/blob/main/mocks/generate.go). 

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).