### PR TITLE
Added option for build timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ registries:
 docker run \
     --rm \
     -e=IMAGE_TAG="0.0.1"\
+    -e=BUILD_TIMEOUT=600\
     -e=GITHUB_USERNAME=$GITHUB_USERNAME \
     -e=GITHUB_PASSWORD=$GITHUB_PASSWORD \
     -e=QUAY_USERNAME=$QUAY_USERNAME\
@@ -115,4 +116,8 @@ docker run \
 ```
 You can override the variables `image_tag` and `image_name` by injecting the environment variable `IMAGE_TAG` `IMAGE_NAME` respectively, set to your chosen string into `carpenter-img` when you run the container.
 
-Additionally, you can override the `quay_img_exp` by injecting the environment variable `QUAY_IMG_EXP`. Configuring this variable from default `never` will update the LABEL added to the image during build time to automatically expire after the time indicated and delete from the repository in Quay. Documentation and time formats can be found [here](https://docs.projectquay.io/use_quay.html#:~:text=Setting%20tag%20expiration%20from%20a%20Dockerfile)
+Additionally, `build_timeout` and `quay_img_exp` can be overridden.
+
+`quay_img_exp` is overwritten by injecting the environment variable `QUAY_IMG_EXP`. Configuring this variable from default `never` will update the LABEL added to the image during build time to automatically expire after the time indicated and delete from the repository in Quay. Documentation and time formats can be found [here](https://docs.projectquay.io/use_quay.html#:~:text=Setting%20tag%20expiration%20from%20a%20Dockerfile)
+
+`build_timeout` is overwritten by injecting the environment variable `BUILD_TIMEOUT`, which accepts an integer representing the number of **seconds** before a build timeouts. You should set this to long enough that it should not fail unless something goes wrong while under the expected system conditions. Builds on automated third party CI will take much longer due to the reduced CPU cycles allocated to a workflow.

--- a/internal/carpentry/carpentry.go
+++ b/internal/carpentry/carpentry.go
@@ -3,14 +3,16 @@ package carpentry
 import (
 	"bytes"
 	"fmt"
+	log2 "log"
+	"os"
+	"path/filepath"
+
 	"go.arcalot.io/imagebuilder/internal/ce_service"
+	"go.arcalot.io/imagebuilder/internal/docker"
 	"go.arcalot.io/imagebuilder/internal/dto"
 	"go.arcalot.io/imagebuilder/internal/images"
 	"go.arcalot.io/imagebuilder/internal/requirements"
 	"go.arcalot.io/log"
-	log2 "log"
-	"os"
-	"path/filepath"
 )
 
 func Carpentry(build_img bool, push_img bool, cec ce_service.ContainerEngineService, conf dto.Carpenter, abspath string,
@@ -38,7 +40,11 @@ func Carpentry(build_img bool, push_img bool, cec ce_service.ContainerEngineServ
 	if !all_checks {
 		return false, nil
 	}
-	if err := images.BuildImage(build_img, all_checks, cec, abspath, conf.Image_Name, conf.Image_Tag, conf.Quay_Img_Exp,
+	build_options := docker.BuildOptions{
+		QuayImgExp:            conf.Quay_Img_Exp,
+		BuildTimeLimitSeconds: conf.Build_Timeout,
+	}
+	if err := images.BuildImage(build_img, all_checks, cec, abspath, conf.Image_Name, conf.Image_Tag, &build_options,
 		logger); err != nil {
 		return false, err
 	}

--- a/internal/ce_service/ce_service.go
+++ b/internal/ce_service/ce_service.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ContainerEngineService interface {
-	Build(filepath string, name string, tags []string, quay_img_exp string) error
+	Build(filepath string, name string, tags []string, build_options *docker.BuildOptions) error
 	Tag(image_tag string, destination string) error
 	Push(destination string, username string, password string, registry_address string) error
 }

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -3,12 +3,13 @@ package docker_test
 import (
 	"bytes"
 	"fmt"
-	"go.arcalot.io/imagebuilder/internal/docker"
 	"io"
 	"log"
 	"os"
 	"strings"
 	"testing"
+
+	"go.arcalot.io/imagebuilder/internal/docker"
 
 	"github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
@@ -29,7 +30,8 @@ func TestClient_BuildImage(t *testing.T) {
 		Client: dockerClientMock,
 	}
 
-	assert.Error(t, client.Build("some", "path", []string{"tag1", "tag2"}, "never"))
+	assert.Error(t, client.Build("some", "path", []string{"tag1", "tag2"},
+		docker.DefaultBuildOptions()))
 }
 
 func TestClient_ImageTag(t *testing.T) {

--- a/internal/dto/carpenter.go
+++ b/internal/dto/carpenter.go
@@ -2,6 +2,7 @@ package dto
 
 import (
 	"fmt"
+
 	"github.com/creasty/defaults"
 	"github.com/spf13/viper"
 	"go.arcalot.io/log"
@@ -13,6 +14,7 @@ type Carpenter struct {
 	Project_Filepath string
 	Image_Tag        string `default:"latest"`
 	Quay_Img_Exp     string `default:"never"`
+	Build_Timeout    uint32 `default:"600"`
 	Registries       []Registry
 }
 
@@ -27,6 +29,7 @@ func Unmarshal(logger log.Logger) (Carpenter, error) {
 		Project_Filepath: viper.GetString("project_filepath"),
 		Image_Tag:        viper.GetString("image_tag"),
 		Quay_Img_Exp:     viper.GetString("quay_img_exp"),
+		Build_Timeout:    viper.GetUint32("build_timeout"),
 		Registries:       filteredRegistries}
 	if err := defaults.Set(&conf); err != nil {
 		return Carpenter{}, fmt.Errorf("error setting carpentry Carpenter defaults (%w)", err)

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -1,18 +1,20 @@
 package images
 
 import (
-	"go.arcalot.io/imagebuilder/internal/ce_service"
-	"go.arcalot.io/log"
 	"strings"
+
+	"go.arcalot.io/imagebuilder/internal/ce_service"
+	"go.arcalot.io/imagebuilder/internal/docker"
+	"go.arcalot.io/log"
 )
 
 func BuildImage(build_img bool, all_checks bool, cec ce_service.ContainerEngineService, abspath string, image_name string,
-	image_tag string, quay_img_exp string, logger log.Logger) error {
+	image_tag string, options *docker.BuildOptions, logger log.Logger) error {
 
 	if all_checks && build_img {
 		logger.Infof("Passed all requirements: %s %s\n", image_name, image_tag)
 		logger.Infof("Building %s %s from %v\n", image_name, image_tag, abspath)
-		if err := cec.Build(abspath, image_name, []string{image_tag}, quay_img_exp); err != nil {
+		if err := cec.Build(abspath, image_name, []string{image_tag}, options); err != nil {
 			return err
 		}
 	}

--- a/internal/images/images_test.go
+++ b/internal/images/images_test.go
@@ -2,13 +2,15 @@ package images_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"go.arcalot.io/assert"
+	"go.arcalot.io/imagebuilder/internal/docker"
 	"go.arcalot.io/imagebuilder/internal/dto"
 	"go.arcalot.io/imagebuilder/internal/images"
 	mocks "go.arcalot.io/imagebuilder/mocks/ce_service"
 	"go.arcalot.io/log"
-	"testing"
 )
 
 func TestBuildImage(t *testing.T) {
@@ -17,10 +19,10 @@ func TestBuildImage(t *testing.T) {
 	defer ctrl.Finish()
 	cec := mocks.NewMockContainerEngineService(ctrl)
 	cec.EXPECT().
-		Build("use", "the", []string{"forks"}, "never").
+		Build("use", "the", []string{"forks"}, docker.DefaultBuildOptions()).
 		Return(nil).
 		Times(1)
-	assert.Nil(t, images.BuildImage(true, true, cec, "use", "the", "forks", "never", logger))
+	assert.Nil(t, images.BuildImage(true, true, cec, "use", "the", "forks", docker.DefaultBuildOptions(), logger))
 }
 
 func TestPushImage(t *testing.T) {

--- a/mocks/ce_service/ce_service.go
+++ b/mocks/ce_service/ce_service.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	docker "go.arcalot.io/imagebuilder/internal/docker"
 )
 
 // MockContainerEngineService is a mock of ContainerEngineService interface.
@@ -34,7 +35,7 @@ func (m *MockContainerEngineService) EXPECT() *MockContainerEngineServiceMockRec
 }
 
 // Build mocks base method.
-func (m *MockContainerEngineService) Build(arg0, arg1 string, arg2 []string, arg3 string) error {
+func (m *MockContainerEngineService) Build(arg0, arg1 string, arg2 []string, arg3 *docker.BuildOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Build", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
## Changes introduced with this PR

This change is required because there is a chance that the build will take longer than 5 minutes on github actions (due to the fewer computational resources granted to workflows). In those cases, the build fails.
It is important now because the recent changes to the template, which were moved to the other repos, added more stages with dnf installs, which added minutes to the build.

I set the default to 10 minutes.

The way I did this adds an option, and packs some related options into a struct. It is probably a better practice to do this than let the config go deep into the program, or use an excessive amount of params.

### Testing

The best way to test this change is to checkout this branch, edit the .carpenter.yaml file in the repo root to have this:
```yaml
image_name: arcaflow-plugin-uperf
image_tag: 'latest'
project_filepath: '<insert your uperf dir path>'
quay_exp: 'never'
build_timeout: 15
registries: []
```

Then run `go run carpenter.go build --build` in the root of the image builder repository.
It should error out in 15 seconds. Comment that out, it should finish before the 10 minute mark.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).