### PR TITLE
Goreleaser carpenter config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - .carpenter.yaml
 dockers:
   - dockerfile: Dockerfile.goreleaser
     image_templates:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,9 +28,9 @@ archives:
 dockers:
   - dockerfile: Dockerfile.goreleaser
     image_templates:
-      - ghcr.io/arcalot/arcaflow-plugin-image-builder:{{ .Tag }}
-      - ghcr.io/arcalot/arcaflow-plugin-image-builder:{{ .Major }}
-      - ghcr.io/arcalot/arcaflow-plugin-image-builder:latest
+      - ghcr.io/mfleader/arcaflow-plugin-image-builder:{{ .Tag }}
+      - ghcr.io/mfleader/arcaflow-plugin-image-builder:{{ .Major }}
+      - ghcr.io/mfleader/arcaflow-plugin-image-builder:latest
     extra_files:
       - .carpenter.yaml
 checksum:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,13 +25,14 @@ archives:
     files:
       - LICENSE
       - README.md
-      - .carpenter.yaml
 dockers:
   - dockerfile: Dockerfile.goreleaser
     image_templates:
       - ghcr.io/arcalot/arcaflow-plugin-image-builder:{{ .Tag }}
       - ghcr.io/arcalot/arcaflow-plugin-image-builder:{{ .Major }}
       - ghcr.io/arcalot/arcaflow-plugin-image-builder:latest
+    extra_files:
+      - .carpenter.yaml
 checksum:
     name_template: 'checksums.txt'
 changelog:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,10 @@
-FROM scratch
-ENTRYPOINT ["/imagebuilder"]
+FROM quay.io/centos/centos:stream8
+
+RUN dnf -y module install python39 &&\
+    dnf -y install python39 python39-pip &&\
+    python3.9 -m pip install --user --upgrade flake8
+    
 COPY imagebuilder /
 COPY .carpenter.yaml /
+
+ENTRYPOINT ["/imagebuilder"]


### PR DESCRIPTION
## Changes introduced with this PR

The image created by goreleaser is missing the Python 3.9 and Flake8 dependencies.

This PR adds the Python 3.9 and Flake8 dependencies, and the base `.carpenter.yaml`, to carpenter's Goreleaser image.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).