### PR TITLE
Quay Custom Namespace integration

### DIFF
--- a/.carpenter.yaml
+++ b/.carpenter.yaml
@@ -12,4 +12,4 @@ registries:
     username_envvar: "QUAY_USERNAME"
     password_envvar: "QUAY_PASSWORD"
     namespace_envvar: "QUAY_NAMESPACE"
-    quay_custom_repo_envvar: "QUAY_CUSTOM_REPO"
+    quay_custom_repo_envvar: "QUAY_CUSTOM_NAMESPACE"

--- a/.carpenter.yaml
+++ b/.carpenter.yaml
@@ -12,4 +12,4 @@ registries:
     username_envvar: "QUAY_USERNAME"
     password_envvar: "QUAY_PASSWORD"
     namespace_envvar: "QUAY_NAMESPACE"
-    quay_custom_repo_envvar: "QUAY_CUSTOM_NAMESPACE"
+    quay_custom_namespace_envvar: "QUAY_CUSTOM_NAMESPACE"

--- a/.carpenter.yaml
+++ b/.carpenter.yaml
@@ -12,3 +12,4 @@ registries:
     username_envvar: "QUAY_USERNAME"
     password_envvar: "QUAY_PASSWORD"
     namespace_envvar: "QUAY_NAMESPACE"
+    quay_custom_repo_envvar: "QUAY_CUSTOM_REPO"

--- a/README.md
+++ b/README.md
@@ -116,8 +116,10 @@ docker run \
 ```
 You can override the variables `image_tag` and `image_name` by injecting the environment variable `IMAGE_TAG` `IMAGE_NAME` respectively, set to your chosen string into `carpenter-img` when you run the container.
 
-Additionally, `build_timeout` and `quay_img_exp` can be overridden.
+Additionally, `build_timeout`,`quay_img_exp`, and `quay_custom_namespace` can be overridden.
 
 `quay_img_exp` is overwritten by injecting the environment variable `QUAY_IMG_EXP`. Configuring this variable from default `never` will update the LABEL added to the image during build time to automatically expire after the time indicated and delete from the repository in Quay. Documentation and time formats can be found [here](https://docs.projectquay.io/use_quay.html#:~:text=Setting%20tag%20expiration%20from%20a%20Dockerfile)
+
+`quay_custom_namespace` is overwritten by injecting the environment variable `QUAY_CUSTOM_NAMESPACE`. This will overwrite the default value of `""`, and additionally use this requested quay namespace to push the image instead of the inferred namespace automatically assigned by carpenter with `QUAY_NAMESPACE`. This is primarly used when carpenter is being utilized in GitHub Actions CI/CD without needing to change the secrets of the repository where `QUAY_NAMESPACE` value is stored if a different location is required.
 
 `build_timeout` is overwritten by injecting the environment variable `BUILD_TIMEOUT`, which accepts an integer representing the number of **seconds** before a build timeouts. You should set this to long enough that it should not fail unless something goes wrong while under the expected system conditions. Builds on automated third party CI will take much longer due to the reduced CPU cycles allocated to a workflow.

--- a/internal/dto/registry.go
+++ b/internal/dto/registry.go
@@ -68,13 +68,13 @@ func (registries Registries) Parse(logger log.Logger) (Registries, error) {
 		password := LookupEnvVar(password_envvar, logger).Return_value
 		namespace := LookupEnvVar(namespace_envvar, logger).Return_value
 		quay_custom_namespace := LookupEnvVar(quay_custom_namespace_envvar, logger).Return_value
-		if registries[i].ValidCredentials(username) {
-			registries[i].Username = username
-			registries[i].Password = password
-		} else {
+		if !registries[i].ValidCredentials(username) {
 			logger.Infof("Missing credentials for %s\n", registries[i].Url)
 			misconfigured_registries[strconv.FormatInt(int64(i), 10)] = PlaceHolder
+			continue
 		}
+		registries[i].Username = username
+		registries[i].Password = password
 		if quay_custom_namespace != "" && registries[i].Url == "quay.io" {
 			registries[i].Namespace = quay_custom_namespace
 		} else {

--- a/internal/dto/registry.go
+++ b/internal/dto/registry.go
@@ -15,7 +15,7 @@ type Registry struct {
 	Username_Envvar              string
 	Password_Envvar              string
 	Namespace_Envvar             string
-	Quay_Custom_Namespace_Envvar string `default:""`
+	Quay_Custom_Namespace_Envvar string
 	Username                     string `default:""`
 	Password                     string `default:""`
 	Namespace                    string `default:""`

--- a/internal/dto/registry.go
+++ b/internal/dto/registry.go
@@ -15,7 +15,7 @@ type Registry struct {
 	Username_Envvar              string
 	Password_Envvar              string
 	Namespace_Envvar             string
-	Quay_Custom_Namespace_Envvar string
+	Quay_Custom_Namespace_Envvar string `default:""`
 	Username                     string `default:""`
 	Password                     string `default:""`
 	Namespace                    string `default:""`
@@ -71,17 +71,18 @@ func (registries Registries) Parse(logger log.Logger) (Registries, error) {
 		if registries[i].ValidCredentials(username) {
 			registries[i].Username = username
 			registries[i].Password = password
-			inferred_namespace, err := InferNamespace(namespace, username)
-			if err != nil {
-				return nil, err
-			}
-			registries[i].Namespace = inferred_namespace
 		} else {
 			logger.Infof("Missing credentials for %s\n", registries[i].Url)
 			misconfigured_registries[strconv.FormatInt(int64(i), 10)] = PlaceHolder
 		}
 		if quay_custom_namespace != "" && registries[i].Url == "quay.io" {
 			registries[i].Namespace = quay_custom_namespace
+		} else {
+			inferred_namespace, err := InferNamespace(namespace, username)
+			if err != nil {
+				return nil, err
+			}
+			registries[i].Namespace = inferred_namespace
 		}
 	}
 	filteredRegistries := FilterByIndex(registries, misconfigured_registries)

--- a/internal/dto/registry.go
+++ b/internal/dto/registry.go
@@ -11,14 +11,14 @@ import (
 )
 
 type Registry struct {
-	Url                     string
-	Username_Envvar         string
-	Password_Envvar         string
-	Namespace_Envvar        string
-	Quay_Custom_Repo_Envvar string
-	Username                string `default:""`
-	Password                string `default:""`
-	Namespace               string `default:""`
+	Url                          string
+	Username_Envvar              string
+	Password_Envvar              string
+	Namespace_Envvar             string
+	Quay_Custom_Namespace_Envvar string
+	Username                     string `default:""`
+	Password                     string `default:""`
+	Namespace                    string `default:""`
 }
 
 type Registries []Registry
@@ -63,16 +63,16 @@ func (registries Registries) Parse(logger log.Logger) (Registries, error) {
 		username_envvar := registries[i].Username_Envvar
 		password_envvar := registries[i].Password_Envvar
 		namespace_envvar := registries[i].Namespace_Envvar
-		quay_custom_repo_envvar := registries[i].Quay_Custom_Repo_Envvar
+		quay_custom_namespace_envvar := registries[i].Quay_Custom_Namespace_Envvar
 		username := LookupEnvVar(username_envvar, logger).Return_value
 		password := LookupEnvVar(password_envvar, logger).Return_value
 		namespace := LookupEnvVar(namespace_envvar, logger).Return_value
-		quay_custom_repo := LookupEnvVar(quay_custom_repo_envvar, logger).Return_value
+		quay_custom_namespace := LookupEnvVar(quay_custom_namespace_envvar, logger).Return_value
 		if registries[i].ValidCredentials(username) {
 			registries[i].Username = username
 			registries[i].Password = password
-			if quay_custom_repo != "" && registries[i].Url == "quay.io" {
-				registries[i].Namespace = quay_custom_repo
+			if quay_custom_namespace != "" && registries[i].Url == "quay.io" {
+				registries[i].Namespace = quay_custom_namespace
 			} else {
 				inferred_namespace, err := InferNamespace(namespace, username)
 				if err != nil {

--- a/internal/dto/registry.go
+++ b/internal/dto/registry.go
@@ -2,11 +2,12 @@ package dto
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
-	"go.arcalot.io/log"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/viper"
+	"go.arcalot.io/log"
 )
 
 type Registry struct {
@@ -17,6 +18,7 @@ type Registry struct {
 	Username         string `default:""`
 	Password         string `default:""`
 	Namespace        string `default:""`
+	Quay_Custom_Repo string `default:""`
 }
 
 type Registries []Registry
@@ -61,9 +63,14 @@ func (registries Registries) Parse(logger log.Logger) (Registries, error) {
 		username_envvar := registries[i].Username_Envvar
 		password_envvar := registries[i].Password_Envvar
 		namespace_envvar := registries[i].Namespace_Envvar
+		quay_custom_repo_envvar := registries[i].Quay_Custom_Repo
 		username := LookupEnvVar(username_envvar, logger).Return_value
 		password := LookupEnvVar(password_envvar, logger).Return_value
 		namespace := LookupEnvVar(namespace_envvar, logger).Return_value
+		quay_custom_repo := LookupEnvVar(quay_custom_repo_envvar, logger).Return_value
+		if quay_custom_repo != "" && registries[i].Url == "quay.io" {
+			registries[i].Namespace = quay_custom_repo
+		}
 		if registries[i].ValidCredentials(username) {
 			registries[i].Username = username
 			registries[i].Password = password

--- a/internal/dto/registry.go
+++ b/internal/dto/registry.go
@@ -71,18 +71,17 @@ func (registries Registries) Parse(logger log.Logger) (Registries, error) {
 		if registries[i].ValidCredentials(username) {
 			registries[i].Username = username
 			registries[i].Password = password
-			if quay_custom_namespace != "" && registries[i].Url == "quay.io" {
-				registries[i].Namespace = quay_custom_namespace
-			} else {
-				inferred_namespace, err := InferNamespace(namespace, username)
-				if err != nil {
-					return nil, err
-				}
-				registries[i].Namespace = inferred_namespace
+			inferred_namespace, err := InferNamespace(namespace, username)
+			if err != nil {
+				return nil, err
 			}
+			registries[i].Namespace = inferred_namespace
 		} else {
 			logger.Infof("Missing credentials for %s\n", registries[i].Url)
 			misconfigured_registries[strconv.FormatInt(int64(i), 10)] = PlaceHolder
+		}
+		if quay_custom_namespace != "" && registries[i].Url == "quay.io" {
+			registries[i].Namespace = quay_custom_namespace
 		}
 	}
 	filteredRegistries := FilterByIndex(registries, misconfigured_registries)


### PR DESCRIPTION
## Changes introduced with this PR

- Creates a way to manually adjust the location of the image being pushed in quay if arcolot is not required. 
- This will allow us to manually insert a location without having to update secrets in github using `QUAY_NAMESPACE`.
- By default it will be left as an empty string and does not effect current process.
- Locally just set the env var `QUAY_CUSTOM_NAMESPACE`
- Example in GitHub CI/CD workflow found [here](https://github.com/jdowni000/arcaflow-reusable-workflows/blob/custom_repo/.github/workflows/carpenter.yaml#:~:text=type%3A%20string-,quay_custom_namespace%3A,-required%3A%20false) using inputs. This change will come next to the reusable workflow repository where carpenter is used currently as a reusable workflow and will need the ability to use inputs. Example of caller workflow [here](https://github.com/jdowni000/arcaflow-plugin-template-python/blob/ae0abf1fabc3715d9b43658542656670b3573952/.github/workflows/carpenter.yaml#:~:text=quay_custom_namespace%3A%20%22jdownie%22).

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).