### PR TITLE
Permissions added to job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,6 +76,8 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     needs:
       - golangci-lint
       - test

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,9 +28,9 @@ archives:
 dockers:
   - dockerfile: Dockerfile.goreleaser
     image_templates:
-      - ghcr.io/mfleader/arcaflow-plugin-image-builder:{{ .Tag }}
-      - ghcr.io/mfleader/arcaflow-plugin-image-builder:{{ .Major }}
-      - ghcr.io/mfleader/arcaflow-plugin-image-builder:latest
+      - ghcr.io/arcalot/arcaflow-plugin-image-builder:{{ .Tag }}
+      - ghcr.io/arcalot/arcaflow-plugin-image-builder:{{ .Major }}
+      - ghcr.io/arcalot/arcaflow-plugin-image-builder:latest
     extra_files:
       - .carpenter.yaml
 checksum:


### PR DESCRIPTION
## Changes introduced with this PR

Permissions are required for goreleaser to push to packages. This is an attempt to fix [this](https://github.com/arcalot/arcaflow-plugin-image-builder/actions/runs/4297099248/jobs/7489662698) error from the previous version release

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).