### PR TITLE
Adjust Dockerfile to minimize container image to smaller footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
+# Build stage
 FROM golang:1.18 AS builder
 COPY . /build
 WORKDIR /build
 RUN CGO_ENABLED=0 go build ./carpenter.go
 
-
-FROM quay.io/centos/centos:stream8
-RUN dnf -y module install python39 &&\
-    dnf -y install python39 python39-pip &&\
-    python3.9 -m pip install --user --upgrade flake8
+# Main stage
+FROM python:3.9.16-alpine3.17
+RUN python -m ensurepip
+RUN python -m pip install --user --upgrade flake8
 
 COPY --from=builder /build/carpenter /
 COPY .carpenter.yaml /.carpenter.yaml
 WORKDIR /
-
 
 ENTRYPOINT ["/carpenter"]
 CMD ["build"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /build
 RUN CGO_ENABLED=0 go build ./carpenter.go
 
 # Main stage
-FROM python:3.9.16-alpine3.17
+FROM python:3.9.16-slim-bullseye
 RUN python -m ensurepip
 RUN python -m pip install --user --upgrade flake8
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,8 +1,6 @@
-FROM quay.io/centos/centos:stream8
+FROM python:3.9.16-alpine3.17
 
-RUN dnf -y module install python39 &&\
-    dnf -y install python39 python39-pip &&\
-    python3.9 -m pip install --user --upgrade flake8
+RUN python -m pip install --user --upgrade flake8
     
 COPY imagebuilder /
 COPY .carpenter.yaml /

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM python:3.9.16-alpine3.17
+FROM python:3.9.16-slim-bullseye
 
 RUN python -m pip install --user --upgrade flake8
     


### PR DESCRIPTION
## Changes introduced with this PR

Adjust Dockerfiles to use smaller base images in order to minimize the container footprint as much as possible. Since this will be part of an action that is run frequently across multiple orgs and locations, this should be an overall boost to efficiency and build speed.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).